### PR TITLE
Change current album menu item to use less variable

### DIFF
--- a/css-less/general.less
+++ b/css-less/general.less
@@ -139,7 +139,7 @@ html, body {
 		&.current-album-menu-item {
 			a {
 				cursor: default;
-				color: #000;
+				color: @selected-menu-item-color;
 				&:hover {
 					border-color: transparent;
 				}


### PR DESCRIPTION
We made a dark theme for Touchfolio and found that the "current-album-menu-item" link was black on black even after we changed "selected-menu-item-color" to white. This small commit changes the default behavior.  Thanks for building such a great theme!

Nathan

Change ".current-album-menu-item a" to use the less variable
"selected-menu-item-color" instead of hardcoded #000 value
