### PR TITLE
Fixed unminimized of jquery.slider.pack.js 

### DIFF
--- a/js/jquery.slider-pack.js
+++ b/js/jquery.slider-pack.js
@@ -410,7 +410,7 @@
 			self._nextImageArr = self.sliderRoot.find('.arrow-right').click(function(e) {
 				e.preventDefault();
 				self.next();
-			});&mdash;
+			});
 		}
 		self._primaryMenu = self._headerSideMenu.find('.primary-menu > .current-menu-item');
 		


### PR DESCRIPTION
When I switched to the unminimized version of the slider I got a console error, so I fixed it (on line 413).
